### PR TITLE
feat: ingestion support for The Atlas of Economic Complexity

### DIFF
--- a/dlctl/cli.py
+++ b/dlctl/cli.py
@@ -13,6 +13,7 @@ from dlctl.dbt_handler import DBTHandler
 from export.cli import export
 from graph.cli import graph
 from ingest.cli import ingest
+from shared.cache import expunge_cache
 from shared.settings import LOCAL_DIR, MART_DB_VARS, env
 from shared.storage import Storage, StoragePrefix
 
@@ -241,6 +242,35 @@ def tools():
 )
 def generate_init_sql(path: str):
     T.generate_init_sql(path)
+
+
+# Cache
+# =====
+
+
+@dlctl.group(help="Manage cache (requests, etc.)")
+def cache():
+    pass
+
+
+@cache.command(name="clean", help="Expunge cache")
+@click.option(
+    "-ns",
+    "--namespace",
+    type=click.Choice(["requests", "huggingface"]),
+    help="Limit cache cleaning to a namespace",
+)
+@click.option(
+    "-n",
+    "--name",
+    type=click.STRING,
+    help="Limit cache cleaning to a specific name (namespace required as well)",
+)
+def cache_clean(namespace: Optional[str], name: Optional[str]):
+    if namespace is None and name is not None:
+        raise click.UsageError("name requires that namespace is set")
+
+    expunge_cache(namespace, name)
 
 
 if __name__ == "__main__":

--- a/ingest/fetcher.py
+++ b/ingest/fetcher.py
@@ -1,0 +1,70 @@
+from pathlib import Path
+from urllib.parse import parse_qs, urljoin, urlsplit, urlunsplit
+
+from loguru import logger as log
+
+from shared.cache import get_requests_cache_session
+
+DATACITE_API_URL = "https://api.datacite.org/"
+
+
+class DataCiteFetcher:
+    def __init__(self):
+        self.session = get_requests_cache_session("datacite")
+
+    def to_canonical_doi(self, doi: str) -> str:
+        rel_path = urlsplit(doi).path.removeprefix("/")
+        canonical_doi = "/".join(rel_path.split("/")[:3])
+        return canonical_doi
+
+    def get_url_from_datacite(self, canonical_doi: str) -> str:
+        dc_api_url = urljoin(DATACITE_API_URL, f"dois/{canonical_doi}")
+
+        dc_api_resp = self.session.get(dc_api_url)
+        dc_api_resp.raise_for_status()
+
+        ds_url = dc_api_resp.json()["data"]["attributes"]["url"]
+
+        return ds_url
+
+    def get_files(self, ds_url: str) -> dict[int, str]:
+        ds_url_parts = urlsplit(ds_url)
+        ds_persistent_id = parse_qs(ds_url_parts.query)["persistentId"][0]
+
+        ds_api_url = urlunsplit(
+            (
+                ds_url_parts.scheme,
+                ds_url_parts.netloc,
+                "/api/datasets/:persistentId",
+                f"persistentId={ds_persistent_id}",
+                "",
+            )
+        )
+
+        ds_api_resp = self.session.get(ds_api_url)
+        ds_files = ds_api_resp.json()["data"]["latestVersion"]["files"]
+
+        files = {}
+
+        for ds_file in ds_files:
+            if "dataFile" not in ds_file:
+                continue
+
+            file_id = ds_file["dataFile"]["id"]
+            filename = ds_file["dataFile"]["filename"]
+
+            files[file_id] = filename
+
+        return files
+
+    def download(self, doi: str, target: Path):
+        log.info("Processing DOI: {}", doi)
+
+        canonical_doi = self.to_canonical_doi(doi)
+        ds_url = self.get_url_from_datacite(canonical_doi)
+
+        files = self.get_files(ds_url)
+
+        for file_id, filename in files.items():
+            download_url = ...
+            print(file_id, filename)

--- a/ingest/handler.py
+++ b/ingest/handler.py
@@ -1,14 +1,14 @@
 import shutil
-from dataclasses import dataclass
-from pathlib import Path
-from urllib.parse import urlparse
 
 import git
 import kagglehub as kh
 from loguru import logger as log
-from platformdirs import user_cache_dir
 from slugify import slugify
 
+from ingest.fetcher import DataCiteFetcher
+from ingest.parser import DatasetURL
+from ingest.template.base import DataCiteTemplate, DatasetTemplate, DatasetTemplateID
+from shared.cache import get_cache_dir
 from shared.storage import Storage, StoragePrefix
 
 
@@ -24,35 +24,20 @@ def handle_standalone(dataset: str):
         log.error("Could not create directory {} for {}: {}", ds_name, dataset, e)
 
 
-@dataclass
-class DatasetURL:
-    author: str
-    slug: str
-    handle: str
-    name: str
+def handle_template(template_id: DatasetTemplateID):
+    template = DatasetTemplate.from_id(template_id)
 
+    match template:
+        case DataCiteTemplate():
+            dcdl = DataCiteFetcher()
 
-def parse_dataset_url(dataset_url: str) -> DatasetURL:
-    url = urlparse(dataset_url)
-    path = url.path.split("/")
-
-    author = path[-2]
-    slug = path[-1]
-    handle = f"{author}/{slug}"
-    name = slugify(slug, separator="_")
-
-    ds_url = DatasetURL(
-        author=author,
-        slug=slug,
-        handle=handle,
-        name=name,
-    )
-
-    return ds_url
+            for source, target, attribution in template:
+                log.info("Downloading: {}", attribution.replace("\n", " ").strip())
+                dcdl.download(doi=source, target=target)
 
 
 def handle_kaggle(dataset_url: str):
-    ds_url = parse_dataset_url(dataset_url)
+    ds_url = DatasetURL.parse(dataset_url)
     log.info("Kaggle dataset detected, downloading dataset: {}", ds_url.name)
 
     try:
@@ -69,18 +54,12 @@ def handle_kaggle(dataset_url: str):
         )
 
 
-def get_cache_dir() -> Path:
-    cache_dir = Path(user_cache_dir("datalab"))
-    cache_dir.mkdir(parents=True, exist_ok=True)
-    return cache_dir
-
-
 def handle_hugging_face(dataset_url: str):
-    ds_url = parse_dataset_url(dataset_url)
+    ds_url = DatasetURL.parse(dataset_url)
     log.info("Hugging Face dataset detected, downloading dataset: {}", ds_url.name)
 
     try:
-        hf_ds_path = get_cache_dir() / ds_url.author / ds_url.slug
+        hf_ds_path = get_cache_dir() / "huggingface" / ds_url.author / ds_url.slug
 
         log.info("Fetching {}", dataset_url)
 

--- a/ingest/parser.py
+++ b/ingest/parser.py
@@ -1,0 +1,32 @@
+from dataclasses import dataclass
+from typing import Self
+from urllib.parse import urlparse
+
+from slugify import slugify
+
+
+@dataclass
+class DatasetURL:
+    author: str
+    slug: str
+    handle: str
+    name: str
+
+    @classmethod
+    def parse(cls, dataset_url: str) -> Self:
+        url = urlparse(dataset_url)
+        path = url.path.split("/")
+
+        author = path[-2]
+        slug = path[-1]
+        handle = f"{author}/{slug}"
+        name = slugify(slug, separator="_")
+
+        ds_url = cls(
+            author=author,
+            slug=slug,
+            handle=handle,
+            name=name,
+        )
+
+        return ds_url

--- a/ingest/template/atlas.py
+++ b/ingest/template/atlas.py
@@ -1,0 +1,13 @@
+from ingest.template.base import DataCiteTemplate, DatasetFileMetadata
+
+
+class TheAtlasOfEconomicComplexityTemplate(DataCiteTemplate):
+    template = [
+        DatasetFileMetadata(
+            source="https://doi.org/10.7910/DVN/XTAQMC",
+            target="rankings/",
+            attribution="""
+                The Growth Lab at Harvard University, 2025, "Growth Projections and Complexity Rankings", https://doi.org/10.7910/DVN/XTAQMC, Harvard Dataverse
+            """,
+        )
+    ]

--- a/ingest/template/base.py
+++ b/ingest/template/base.py
@@ -1,0 +1,65 @@
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+from typing import Iterator, Optional, Self
+
+
+class DatasetTemplateID(Enum):
+    THE_ATLAS_OF_ECONOMIC_COMPLEXITY = "atlas"
+
+
+@dataclass
+class DatasetFileMetadata:
+    def __init__(
+        self,
+        source: str,
+        target: str | Path,
+        attribution: Optional[str] = None,
+    ):
+        self.source = source
+
+        if isinstance(target, Path):
+            self.target = target
+        elif isinstance(target, str):
+            self.target = Path(target)
+        else:
+            raise TypeError("Invalid type: target must either be a Path or a str")
+
+        self.attribution = attribution
+
+    def __iter__(self):
+        yield self.source
+        yield self.target
+        yield self.attribution
+
+
+class DatasetTemplate(ABC):
+    @classmethod
+    def from_id(cls, template_id: DatasetTemplateID) -> Self:
+        """Instance child classes based on the DatasetTemplateID"""
+        match template_id:
+            case DatasetTemplateID.THE_ATLAS_OF_ECONOMIC_COMPLEXITY:
+                from ingest.template.atlas import TheAtlasOfEconomicComplexityTemplate
+
+                return TheAtlasOfEconomicComplexityTemplate()
+
+    def __iter__(self) -> Iterator[DatasetFileMetadata]:
+        """Iterate over the dataset files in the template."""
+        yield from self.template
+
+    @property
+    @abstractmethod
+    def template(self) -> list[DatasetFileMetadata]:
+        """
+        Source and target metadata for dataset files.
+
+
+        - The source might be a filename, a URL, a table name, etc.
+        - The target will be a destination dir Path where the source should be dropped.
+        - Attribution is used to comply with legal requirements and will be printed whenever the dataset file is accessed.
+        """
+
+
+class DataCiteTemplate(DatasetTemplate):
+    pass

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ dependencies = [
   "platformdirs>=4.3.8",
   "prompt-toolkit>=3.0.51",
   "python-slugify>=8.0.4",
+  "requests-cache>=1.2.1",
   "torch>=2.7.1",
 ]
 

--- a/shared/cache.py
+++ b/shared/cache.py
@@ -1,0 +1,36 @@
+import shutil
+from pathlib import Path
+from typing import Optional
+
+from loguru import logger as log
+from platformdirs import user_cache_dir
+from requests_cache.session import CachedSession
+
+
+def get_cache_dir() -> Path:
+    cache_dir = Path(user_cache_dir("datalab"))
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    return cache_dir
+
+
+def get_requests_cache_session(name: str) -> CachedSession:
+    cache_dir = get_cache_dir() / "requests" / name
+    session = CachedSession(cache_name=cache_dir, backend="filesystem")
+    return session
+
+
+def expunge_cache(namespace: Optional[str] = None, name: Optional[str] = None):
+    cache_dir = get_cache_dir()
+
+    match (namespace, name):
+        case (None, None):
+            log.info("Cleaning cache completely")
+            shutil.rmtree(cache_dir)
+        case (_, None):
+            log.info("Cleaning cache for {}", namespace)
+            shutil.rmtree(cache_dir / namespace)
+        case (None, _):
+            raise ValueError("name requires namespace to be set")
+        case _:
+            log.info("Cleaning cache for {}: {}", namespace, name)
+            shutil.rmtree(cache_dir / namespace / name)

--- a/uv.lock
+++ b/uv.lock
@@ -165,6 +165,19 @@ wheels = [
 ]
 
 [[package]]
+name = "cattrs"
+version = "25.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/57/2b/561d78f488dcc303da4639e02021311728fb7fda8006dd2835550cddd9ed/cattrs-25.1.1.tar.gz", hash = "sha256:c914b734e0f2d59e5b720d145ee010f1fd9a13ee93900922a2f3f9d593b8382c", size = 435016, upload-time = "2025-06-04T20:27:15.44Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/b0/215274ef0d835bbc1056392a367646648b6084e39d489099959aefcca2af/cattrs-25.1.1-py3-none-any.whl", hash = "sha256:1b40b2d3402af7be79a7e7e097a9b4cd16d4c06e6d526644b0b26a063a1cc064", size = 69386, upload-time = "2025-06-04T20:27:13.969Z" },
+]
+
+[[package]]
 name = "certifi"
 version = "2025.4.26"
 source = { registry = "https://pypi.org/simple" }
@@ -286,6 +299,7 @@ dependencies = [
     { name = "platformdirs" },
     { name = "prompt-toolkit" },
     { name = "python-slugify" },
+    { name = "requests-cache" },
     { name = "torch" },
 ]
 
@@ -319,6 +333,7 @@ requires-dist = [
     { name = "platformdirs", specifier = ">=4.3.8" },
     { name = "prompt-toolkit", specifier = ">=3.0.51" },
     { name = "python-slugify", specifier = ">=8.0.4" },
+    { name = "requests-cache", specifier = ">=1.2.1" },
     { name = "torch", specifier = ">=2.7.1" },
 ]
 
@@ -1591,6 +1606,23 @@ wheels = [
 ]
 
 [[package]]
+name = "requests-cache"
+version = "1.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "cattrs" },
+    { name = "platformdirs" },
+    { name = "requests" },
+    { name = "url-normalize" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1a/be/7b2a95a9e7a7c3e774e43d067c51244e61dea8b120ae2deff7089a93fb2b/requests_cache-1.2.1.tar.gz", hash = "sha256:68abc986fdc5b8d0911318fbb5f7c80eebcd4d01bfacc6685ecf8876052511d1", size = 3018209, upload-time = "2024-06-18T17:18:03.774Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4e/2e/8f4051119f460cfc786aa91f212165bb6e643283b533db572d7b33952bd2/requests_cache-1.2.1-py3-none-any.whl", hash = "sha256:1285151cddf5331067baa82598afe2d47c7495a1334bfe7a7d329b43e9fd3603", size = 61425, upload-time = "2024-06-18T17:17:45Z" },
+]
+
+[[package]]
 name = "requests-toolbelt"
 version = "1.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1898,6 +1930,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/95/32/1a225d6164441be760d75c2c42e2780dc0873fe382da3e98a2e1e48361e5/tzdata-2025.2.tar.gz", hash = "sha256:b60a638fcc0daffadf82fe0f57e53d06bdec2f36c4df66280ae79bce6bd6f2b9", size = 196380, upload-time = "2025-03-23T13:54:43.652Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5c/23/c7abc0ca0a1526a0774eca151daeb8de62ec457e77262b66b359c3c7679e/tzdata-2025.2-py2.py3-none-any.whl", hash = "sha256:1a403fada01ff9221ca8044d701868fa132215d84beb92242d9acd2147f667a8", size = 347839, upload-time = "2025-03-23T13:54:41.845Z" },
+]
+
+[[package]]
+name = "url-normalize"
+version = "2.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/80/31/febb777441e5fcdaacb4522316bf2a527c44551430a4873b052d545e3279/url_normalize-2.2.1.tar.gz", hash = "sha256:74a540a3b6eba1d95bdc610c24f2c0141639f3ba903501e61a52a8730247ff37", size = 18846, upload-time = "2025-04-26T20:37:58.553Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bc/d9/5ec15501b675f7bc07c5d16aa70d8d778b12375686b6efd47656efdc67cd/url_normalize-2.2.1-py3-none-any.whl", hash = "sha256:3deb687587dc91f7b25c9ae5162ffc0f057ae85d22b1e15cf5698311247f567b", size = 14728, upload-time = "2025-04-26T20:37:57.217Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
The Atlas of Economic Complexity is a dataset that can be used, among other things, to produce economic networks that we can study. This is to handle ingestion for this dataset, and also to facilitate future ingestion of other DataCite datasets.